### PR TITLE
Fix: The upcast code was assuming that the editor uses a HTMLDataProc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@ckeditor/ckeditor5-editor-classic": "^19.0.0",
     "@ckeditor/ckeditor5-engine": "^19.0.0",
     "@ckeditor/ckeditor5-indent": "^19.0.0",
+    "@ckeditor/ckeditor5-markdown-gfm": "^17.0.0",
     "@ckeditor/ckeditor5-paragraph": "^19.0.0",
     "@ckeditor/ckeditor5-undo": "^19.0.0",
     "eslint": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@ckeditor/ckeditor5-editor-classic": "^19.0.0",
     "@ckeditor/ckeditor5-engine": "^19.0.0",
     "@ckeditor/ckeditor5-indent": "^19.0.0",
-    "@ckeditor/ckeditor5-markdown-gfm": "^17.0.0",
+    "@ckeditor/ckeditor5-markdown-gfm": "^19.0.0",
     "@ckeditor/ckeditor5-paragraph": "^19.0.0",
     "@ckeditor/ckeditor5-undo": "^19.0.0",
     "eslint": "^5.5.0",

--- a/src/codeblockediting.js
+++ b/src/codeblockediting.js
@@ -128,7 +128,7 @@ export default class CodeBlockEditing extends Plugin {
 		editor.editing.downcastDispatcher.on( 'insert:codeBlock', modelToViewCodeBlockInsertion( model, normalizedLanguagesDefs, true ) );
 		editor.data.downcastDispatcher.on( 'insert:codeBlock', modelToViewCodeBlockInsertion( model, normalizedLanguagesDefs ) );
 		editor.data.downcastDispatcher.on( 'insert:softBreak', modelToDataViewSoftBreakInsertion( model ), { priority: 'high' } );
-		editor.data.upcastDispatcher.on( 'element:pre', dataViewToModelCodeBlockInsertion( editor.data, normalizedLanguagesDefs ) );
+		editor.data.upcastDispatcher.on( 'element:pre', dataViewToModelCodeBlockInsertion( normalizedLanguagesDefs ) );
 
 		// Intercept the clipboard input (paste) when the selection is anchored in the code block and force the clipboard
 		// data to be pasted as a single plain text. Otherwise, the code lines will split the code block and

--- a/src/converters.js
+++ b/src/converters.js
@@ -7,6 +7,7 @@
  * @module code-block/converters
  */
 
+import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import {
 	rawSnippetTextToModelDocumentFragment,
 	getPropertyAssociation
@@ -126,12 +127,11 @@ export function modelToDataViewSoftBreakInsertion( model ) {
  *
  *		<codeBlock language="javascript">foo();<softBreak></softBreak>bar();</codeBlock>
  *
- * @param {module:engine/controller/datacontroller~DataController} dataController
  * @param {Array.<module:code-block/codeblock~CodeBlockLanguageDefinition>} languageDefs The normalized language
  * configuration passed to the feature.
  * @returns {Function} Returns a conversion callback.
  */
-export function dataViewToModelCodeBlockInsertion( dataController, languageDefs ) {
+export function dataViewToModelCodeBlockInsertion( languageDefs ) {
 	// Language names associated with CSS classes:
 	//
 	//		{
@@ -142,6 +142,8 @@ export function dataViewToModelCodeBlockInsertion( dataController, languageDefs 
 	//		}
 	const classesToLanguages = getPropertyAssociation( languageDefs, 'class', 'language' );
 	const defaultLanguageName = languageDefs[ 0 ].language;
+
+	const htmlDataProcessor = new HtmlDataProcessor();
 
 	return ( evt, data, conversionApi ) => {
 		const viewItem = data.viewItem;
@@ -183,7 +185,7 @@ export function dataViewToModelCodeBlockInsertion( dataController, languageDefs 
 			writer.setAttribute( 'language', defaultLanguageName, codeBlock );
 		}
 
-		const stringifiedElement = dataController.processor.toData( viewChild );
+		const stringifiedElement = htmlDataProcessor.toData( viewChild );
 		const textData = extractDataFromCodeElement( stringifiedElement );
 		const fragment = rawSnippetTextToModelDocumentFragment( writer, textData );
 

--- a/tests/markdown.js
+++ b/tests/markdown.js
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import GFMDataProcessor from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataprocessor';
+import CodeBlockEditing from '../src/codeblockediting';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+
+function getEditor( initialData = '' ) {
+	return ClassicTestEditor
+		.create( initialData, {
+			plugins: [ GFMDataProcessor, CodeBlockEditing, Enter, Paragraph ],
+			dataProcessor: new GFMDataProcessor()
+		} );
+}
+
+describe( 'Markdown', () => {
+	it( 'should be loaded and returned from the editor', () => {
+		const markdown =
+			'```\n' +
+			'test()\n' +
+			'```';
+
+		return getEditor( markdown ).then( editor => {
+			expect( editor.getData() ).to.equal( markdown );
+		} );
+	} );
+} );

--- a/tests/markdown.js
+++ b/tests/markdown.js
@@ -4,23 +4,31 @@
  */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
-import GFMDataProcessor from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataprocessor';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import CodeBlockEditing from '../src/codeblockediting';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import GFMDataProcessor from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataprocessor';
+
+// A simple plugin that enables the GFM data processor.
+class Markdown extends Plugin {
+	constructor( editor ) {
+		super( editor );
+		editor.data.processor = new GFMDataProcessor();
+	}
+}
 
 function getEditor( initialData = '' ) {
 	return ClassicTestEditor
 		.create( initialData, {
-			plugins: [ GFMDataProcessor, CodeBlockEditing, Enter, Paragraph ],
-			dataProcessor: new GFMDataProcessor()
+			plugins: [ Markdown, CodeBlockEditing, Enter, Paragraph ]
 		} );
 }
 
 describe( 'Markdown', () => {
 	it( 'should be loaded and returned from the editor', () => {
 		const markdown =
-			'```\n' +
+			'```plaintext\n' +
 			'test()\n' +
 			'```';
 

--- a/tests/markdown.js
+++ b/tests/markdown.js
@@ -28,12 +28,17 @@ function getEditor( initialData = '' ) {
 describe( 'Markdown', () => {
 	it( 'should be loaded and returned from the editor', () => {
 		const markdown =
-			'```plaintext\n' +
+			'```\n' +
 			'test()\n' +
 			'```';
 
 		return getEditor( markdown ).then( editor => {
-			expect( editor.getData() ).to.equal( markdown );
+			// This is to account to the new behavior of the markdown plugin after its code revamp.
+			// This cleanup could be removed later on, once the revamp is merged.
+			let data = editor.getData();
+			data = data.replace( 'plaintext', '' );
+
+			expect( data ).to.equal( markdown );
 		} );
 	} );
 } );

--- a/tests/markdown.js
+++ b/tests/markdown.js
@@ -14,7 +14,7 @@ import GFMDataProcessor from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataproces
 class Markdown extends Plugin {
 	constructor( editor ) {
 		super( editor );
-		editor.data.processor = new GFMDataProcessor();
+		editor.data.processor = new GFMDataProcessor( editor.data.viewDocument );
 	}
 }
 

--- a/tests/markdown.js
+++ b/tests/markdown.js
@@ -39,6 +39,8 @@ describe( 'Markdown', () => {
 			data = data.replace( 'plaintext', '' );
 
 			expect( data ).to.equal( markdown );
+
+			editor.destroy(); // Tests cleanup.
 		} );
 	} );
 } );


### PR DESCRIPTION
…essor, which is not always true.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: code blocks upcasting throws when using the markdown DP. Closes [ckeditor/ckeditor5#5977](https://github.com/ckeditor/ckeditor5/issues/5977).