### PR TITLE
I/5924: Fix multiple classes case in languages config

### DIFF
--- a/docs/features/code-blocks.md
+++ b/docs/features/code-blocks.md
@@ -42,7 +42,7 @@ ClassicEditor
 
 {@snippet features/code-block-custom-languages}
 
-By default, the CSS class of the `<code>` element in the data and editing is generated using the `language` property (prefixed with "language-"). You can customize it by specifying an optional `class` property:
+By default, the CSS class of the `<code>` element in the data and editing is generated using the `language` property (prefixed with "language-"). You can customize it by specifying an optional `class` property. You can set **multiple classes** but **only the first one** will be used as defining language class:
 
 ```js
 ClassicEditor
@@ -55,8 +55,8 @@ ClassicEditor
 				// Use the "php-code" class for PHP code blocks.
 				{ language: 'php', label: 'PHP', class: 'php-code' },
 
-				// Use the "js" class for JavaScript code blocks.
-				{ language: 'javascript', label: 'JavaScript', class: 'js' },
+				// Use the "js" class for JavaScript code blocks (the first class is defining).
+				{ language: 'javascript', label: 'JavaScript', class: 'js javascript js-code' },
 
 				// Python code blocks will have the default "language-python" CSS class.
 				{ language: 'python', label: 'Python' }

--- a/docs/features/code-blocks.md
+++ b/docs/features/code-blocks.md
@@ -55,7 +55,8 @@ ClassicEditor
 				// Use the "php-code" class for PHP code blocks.
 				{ language: 'php', label: 'PHP', class: 'php-code' },
 
-				// Use the "js" class for JavaScript code blocks (the first class is defining).
+				// Use the "js" class for JavaScript code blocks.
+				// Note that only the first ("js") class will determine the language of the block when loading data.
 				{ language: 'javascript', label: 'JavaScript', class: 'js javascript js-code' },
 
 				// Python code blocks will have the default "language-python" CSS class.

--- a/src/codeblock.js
+++ b/src/codeblock.js
@@ -51,7 +51,7 @@ export default class CodeBlock extends Plugin {
  *
  *		ClassicEditor
  *			.create( editorElement, {
- * 				codeBlock:  ... // The code block feature configuration.
+ *				codeBlock:  ... // The code block feature configuration.
  *			} )
  *			.then( ... )
  *			.catch( ... );
@@ -111,12 +111,13 @@ export default class CodeBlock extends Plugin {
  *				codeBlock: {
  *					languages: [
  *						// Do not render the CSS class for the plain text code blocks.
- * 						{ language: 'plaintext', label: 'Plain text', class: '' },
+ *						{ language: 'plaintext', label: 'Plain text', class: '' },
  *
  *						// Use the "php-code" class for PHP code blocks.
  *						{ language: 'php', label: 'PHP', class: 'php-code' },
  *
- * 						// Use the "js" class for JavaScript code blocks (the first class is defining).
+ *						// Use the "js" class for JavaScript code blocks.
+ *						// Note that only the first ("js") class will determine the language of the block when loading data.
  *						{ language: 'javascript', label: 'JavaScript', class: 'js javascript js-code' },
  *
  *						// Python code blocks will have the default "language-python" CSS class.

--- a/src/codeblock.js
+++ b/src/codeblock.js
@@ -116,7 +116,7 @@ export default class CodeBlock extends Plugin {
  *						// Use the "php-code" class for PHP code blocks.
  *						{ language: 'php', label: 'PHP', class: 'php-code' },
  *
- *						// Use only the "js" class for JavaScript code blocks.
+ * 						// Use the "js" class for JavaScript code blocks (the first class is defining).
  *						{ language: 'javascript', label: 'JavaScript', class: 'js javascript js-code' },
  *
  *						// Python code blocks will have the default "language-python" CSS class.

--- a/src/codeblock.js
+++ b/src/codeblock.js
@@ -103,7 +103,8 @@ export default class CodeBlock extends Plugin {
  *
  *		<pre><code class="language-javascript">window.alert( 'Hello world!' )</code></pre>
  *
- * You can customize the CSS class by specifying an optional `class` property in the language definition:
+ * You can customize the CSS class by specifying an optional `class` property in the language definition.
+ * You can set **multiple classes** but **only the first one** will be used as defining language class:
  *
  *		ClassicEditor
  *			.create( document.querySelector( '#editor' ), {
@@ -115,8 +116,8 @@ export default class CodeBlock extends Plugin {
  *						// Use the "php-code" class for PHP code blocks.
  *						{ language: 'php', label: 'PHP', class: 'php-code' },
  *
- *						// Use the "js" class for JavaScript code blocks.
- *						{ language: 'javascript', label: 'JavaScript', class: 'js' },
+ *						// Use only the "js" class for JavaScript code blocks.
+ *						{ language: 'javascript', label: 'JavaScript', class: 'js javascript js-code' },
  *
  *						// Python code blocks will have the default "language-python" CSS class.
  *						{ language: 'python', label: 'Python' }

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,7 +74,16 @@ export function getNormalizedAndLocalizedLanguageDefinitions( editor ) {
  * @param {Object.<String,String>}
  */
 export function getPropertyAssociation( languageDefs, key, value ) {
-	return Object.assign( {}, ...languageDefs.map( def => ( { [ def[ key ] ]: def[ value ] } ) ) );
+	return Object.assign( {}, ...languageDefs.map( def => {
+		// Check if element has multiple classes, and if so
+		// take only the first one as a defining language class
+		if ( key === 'class' && def[ key ].indexOf( ' ' ) !== -1 ) {
+			const languageClass = def[ key ].split( ' ' )[ 0 ];
+
+			return { [ languageClass ]: def[ value ] };
+		}
+
+		return { [ def[ key ] ]: def[ value ] }; } ) );
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,6 +78,7 @@ export function getPropertyAssociation( languageDefs, key, value ) {
 
 	for ( const def of languageDefs ) {
 		if ( key === 'class' ) {
+			// Only the first class is considered.
 			association[ def[ key ].split( ' ' ).shift() ] = def[ value ];
 		} else {
 			association[ def[ key ] ] = def[ value ];

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,16 +74,17 @@ export function getNormalizedAndLocalizedLanguageDefinitions( editor ) {
  * @param {Object.<String,String>}
  */
 export function getPropertyAssociation( languageDefs, key, value ) {
-	return Object.assign( {}, ...languageDefs.map( def => {
-		// Check if element has multiple classes, and if so
-		// take only the first one as a defining language class
-		if ( key === 'class' && def[ key ].indexOf( ' ' ) !== -1 ) {
-			const languageClass = def[ key ].split( ' ' )[ 0 ];
+	const association = {};
 
-			return { [ languageClass ]: def[ value ] };
+	for ( const def of languageDefs ) {
+		if ( key === 'class' ) {
+			association[ def[ key ].split( ' ' ).shift() ] = def[ value ];
+		} else {
+			association[ def[ key ] ] = def[ value ];
 		}
+	}
 
-		return { [ def[ key ] ]: def[ value ] }; } ) );
+	return association;
 }
 
 /**

--- a/tests/codeblockediting.js
+++ b/tests/codeblockediting.js
@@ -781,6 +781,38 @@ describe( 'CodeBlockEditing', () => {
 					return editor.destroy();
 				} );
 		} );
+
+		it( 'should set multiple classes on the <code> if it was configured so', () => {
+			const element = document.createElement( 'div' );
+			document.body.appendChild( element );
+
+			return ClassicTestEditor
+				.create( element, {
+					plugins: [ CodeBlockEditing, AlignmentEditing, BoldEditing, Enter, Paragraph ],
+					codeBlock: {
+						languages: [
+							{ language: 'javascript', label: 'JavaScript', class: 'language-js' },
+							{ language: 'swift', label: 'Swift', class: 'swift ios-code' },
+						]
+					}
+				} )
+				.then( editor => {
+					const model = editor.model;
+
+					setModelData( model,
+						'<codeBlock language="swift">foo</codeBlock>' +
+						'<codeBlock language="javascript">foo</codeBlock>'
+					);
+					expect( editor.getData() ).to.equal(
+						'<pre><code class="swift ios-code">foo</code></pre>' +
+						'<pre><code class="language-js">foo</code></pre>'
+					);
+
+					element.remove();
+
+					return editor.destroy();
+				} );
+		} );
 	} );
 
 	describe( 'data pipeline v -> m conversion ', () => {
@@ -1007,6 +1039,25 @@ describe( 'CodeBlockEditing', () => {
 
 						return editor.destroy();
 					} );
+			} );
+
+			it( 'should upcast using only the first class from config as a defining language class', () => {
+				return ClassicTestEditor.create( '<pre><code class="baz">foo</code></pre>', {
+					plugins: [ CodeBlockEditing ],
+					codeBlock: {
+						languages: [
+							{ language: 'foo', label: 'Foo', class: 'foo' },
+							{ language: 'baz', label: 'Baz', class: 'baz bar' },
+							{ language: 'bar', label: 'Bar', class: 'bar' },
+						]
+					}
+				} ).then( editor => {
+					model = editor.model;
+
+					expect( getModelData( model ) ).to.equal( '<codeBlock language="baz">[]foo</codeBlock>' );
+
+					return editor.destroy();
+				} );
 			} );
 		} );
 	} );

--- a/tests/codeblockediting.js
+++ b/tests/codeblockediting.js
@@ -1043,19 +1043,41 @@ describe( 'CodeBlockEditing', () => {
 
 			// https://github.com/ckeditor/ckeditor5/issues/5924
 			it( 'should upcast using only the first class from config as a defining language class', () => {
+				// "baz" is the first class configured for the "baz" language.
 				return ClassicTestEditor.create( '<pre><code class="baz">foo</code></pre>', {
 					plugins: [ CodeBlockEditing ],
 					codeBlock: {
 						languages: [
 							{ language: 'foo', label: 'Foo', class: 'foo' },
 							{ language: 'baz', label: 'Baz', class: 'baz bar' },
-							{ language: 'bar', label: 'Bar', class: 'bar' },
+							{ language: 'qux', label: 'Qux', class: 'qux' },
 						]
 					}
 				} ).then( editor => {
 					model = editor.model;
 
 					expect( getModelData( model ) ).to.equal( '<codeBlock language="baz">[]foo</codeBlock>' );
+
+					return editor.destroy();
+				} );
+			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/5924
+			it( 'should not upcast if the class is not the first (defining) language class', () => {
+				// "bar" is the second class configured for the "baz" language.
+				return ClassicTestEditor.create( '<pre><code class="bar">foo</code></pre>', {
+					plugins: [ CodeBlockEditing ],
+					codeBlock: {
+						languages: [
+							{ language: 'foo', label: 'Foo', class: 'foo' },
+							{ language: 'baz', label: 'Baz', class: 'baz bar' },
+							{ language: 'qux', label: 'Qux', class: 'qux' },
+						]
+					}
+				} ).then( editor => {
+					model = editor.model;
+
+					expect( getModelData( model ) ).to.equal( '<codeBlock language="foo">[]foo</codeBlock>' );
 
 					return editor.destroy();
 				} );

--- a/tests/codeblockediting.js
+++ b/tests/codeblockediting.js
@@ -1041,6 +1041,7 @@ describe( 'CodeBlockEditing', () => {
 					} );
 			} );
 
+			// https://github.com/ckeditor/ckeditor5/issues/5924
 			it( 'should upcast using only the first class from config as a defining language class', () => {
 				return ClassicTestEditor.create( '<pre><code class="baz">foo</code></pre>', {
 					plugins: [ CodeBlockEditing ],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Use multiple classes in languages config. Closes https://github.com/ckeditor/ckeditor5/issues/5924.

---

### Additional information

* With this fix you can use multiple classes in languages config. Please keep in mind that only the first class will be used as a defining language class. Docs have been updated as well.
