### PR TITLE
ckeditor5-dev/i/611: Fixed stylelint errors related to colors and indentation

### DIFF
--- a/theme/codeblock.css
+++ b/theme/codeblock.css
@@ -5,7 +5,7 @@
 
 .ck-content pre {
 	padding: 1em;
-	color: #353535;
+	color: hsl(0, 0%, 20.8%);
 	background: hsla(0, 0%, 78%, 0.3);
 	border: 1px solid hsl(0, 0%, 77%);
 	border-radius: 2px;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed stylelint errors related to colors and indentation (see ckeditor/ckeditor5-dev#611).
